### PR TITLE
fix for 'stuck' painting state

### DIFF
--- a/js/paint.js
+++ b/js/paint.js
@@ -38,11 +38,13 @@ canvas.addEventListener("mousedown", event => {
   paint(event);
   lastPaint = event;
 });
-canvas.addEventListener("mouseup", event => {
-  event.preventDefault();
-  lastPaint = null;
+document.body.addEventListener("mouseup", event => {
   clearInterval(repeat);
-  painting = false;
+  if (painting) {
+    event.preventDefault();
+    lastPaint = null;
+    painting = false;
+  }
 });
 canvas.addEventListener("mousemove", event => {
   clearInterval(repeat);


### PR DESCRIPTION
Hi! I love your game a lot.

This is a tiny fix for a state where if you start to paint and then drag outside of the canvas, you get "stuck" in a painting state until you click again. This fixes that by canceling a paint on `mouseup` anywhere in the document.

The other way to fix this is to add `painting = false` to the `mouseleave` event, but that stops you from dragging back and forth across the whole canvas smoothly — I think this is a bit nicer despite the global `mouseup` handler.