### PR TITLE
Fix manifest to make site "installable"

### DIFF
--- a/assets/site.webmanifest
+++ b/assets/site.webmanifest
@@ -1,14 +1,16 @@
 {
     "name": "sandspiel",
     "short_name": "sandspiel",
+    "start_url": "https://sandspiel.club/",
+    "scope": "https://sandspiel.club/",
     "icons": [
         {
-            "src": "/android-chrome-192x192.png",
+            "src": "/assets/android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/android-chrome-256x256.png",
+            "src": "/assets/android-chrome-256x256.png",
             "sizes": "256x256",
             "type": "image/png"
         }


### PR DESCRIPTION
* Adds ["start_url"](https://www.w3.org/TR/appmanifest/#start_url-member) which Chrome requires for the site to be considered installable
* Adds ["scope"](https://www.w3.org/TR/appmanifest/#scope-member), which is not required but recommended
* Fixes icon links

I think we are still missing a 512x512 icon in order to be considered "installable" by chrome, but this should still help.