### PR TITLE
Filter out non-integer values from the species enum

### DIFF
--- a/js/components/ui.js
+++ b/js/components/ui.js
@@ -395,7 +395,7 @@ class Index extends React.Component {
         >
           Wind
         </button>
-        {Object.keys(Species).map((n) =>
+        {Object.keys(Species).filter(x => !Number.isInteger(Number.parseInt(x))).map((n) =>
           ElementButton(n, selectedElement, (id) =>
             this.setState({ selectedElement: id })
           )

--- a/js/render.js
+++ b/js/render.js
@@ -73,7 +73,7 @@ let snapshot = (universe) => {
 let pallette = () => {
   let canvas = document.createElement("canvas");
 
-  let species = Object.values(Species);
+  let species = Object.values(Species).filter(x => Number.isInteger(x));;
   let range = Math.max(...species) + 1;
   let universe = Universe.new(range, 1);
   canvas.width = range;


### PR DESCRIPTION
For compatibility with new wasm-bindgen reverse enum mappings. This is the same change as https://github.com/MaxBittker/orb.farm/pull/11 to work around the issues introduced by https://github.com/rustwasm/wasm-bindgen/pull/2240