### PR TITLE
Paste SVG string to load it into Sandspiel Universe

### DIFF
--- a/js/components/ui.js
+++ b/js/components/ui.js
@@ -9,6 +9,7 @@ import { snapshot, pallette } from "../render.js";
 import { functions, storage } from "../api.js";
 import SignInButton from "./signinButton.js";
 import Promotab from "./promotab";
+import { svgToImageData, rgbaToSpecies } from "../convertSVG"
 
 import Menu from "./menu";
 
@@ -234,6 +235,36 @@ class Index extends React.Component {
           this.setState({ submissionMenuOpen: false, submitting: false });
         });
     });
+  }
+
+  async loadSVG (svgString) {
+    const imgData = await svgToImageData(svgString);
+
+    const cellsData = new Uint8Array(
+      memory.buffer,
+      universe.cells(),
+      width * height * 4
+    );
+
+    reset();
+    window.stopboot = true;
+
+    for (let i = 0, len = width * height * 4; i < len; i += 4) {
+      const species = rgbaToSpecies(
+        imgData.data[i], 
+        imgData.data[i + 1], 
+        imgData.data[i + 2], 
+        imgData.data[i + 3]
+      )
+      cellsData[i] = species; // should be 0 to 19
+      cellsData[i+1] = Math.floor(100 + Math.random() * 50); // register A
+      cellsData[i+2] = 0; // register B
+      cellsData[i+3] = 0; // clock
+    }
+    universe.flush_undos();
+    universe.push_undo();
+
+    this.pause();
   }
 
   load() {

--- a/js/convertSVG.js
+++ b/js/convertSVG.js
@@ -73,7 +73,7 @@ export function rgbaToSpecies(r, g, b, a) {
     [ Species.Cloner, Species.Mite, null ], // Violet
   ];
 
-  const species = colorsToSpecies[hueIndex][lightnessIndex];
+  const species = colorsToSpecies?.[hueIndex]?.[lightnessIndex];
 
   return species ? species : Species.Empty;
 }

--- a/js/convertSVG.js
+++ b/js/convertSVG.js
@@ -60,7 +60,7 @@ export function rgbaToSpecies(r, g, b, a) {
   }
 
   // Color options
-  let hueIndex = Math.floor((h+30) / 360 * 7);
+  let hueIndex = Math.floor((h + 25.7) / 360 * 7);
   let lightnessIndex = Math.floor(l * 4 - 0.25);
 
   const colorsToSpecies = [
@@ -83,15 +83,30 @@ export async function svgToImageData (svgString) {
   const height = 300;
 
   return new Promise((resolve, reject) => {
-    // To fit any SVG, we would need to parse the SVG string and set the width
-    // and height attributes to 300. It seems safer to not parse the SVG, and
-    // just load it in an image element.
-    const blob = new Blob([svgString], {type: 'image/svg+xml'});
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(svgString, "image/svg+xml");
+  
+    const errorNode = doc.querySelector("parsererror");
+    if (errorNode) {
+      reject("Error while parsing SVG.");
+      return;
+    } 
+    
+    // We want to fit any pasted SVG to the default Sandspiel universe size.
+    doc.documentElement.setAttribute("width", width + "px");
+    doc.documentElement.setAttribute("height", height + "px");
+  
+    const serializer = new XMLSerializer();
+    const svgStringSized = serializer.serializeToString(doc);
+
+    // Load the SVG into an image element
+    const blob = new Blob([svgStringSized], {type: 'image/svg+xml'});
     const img = document.createElement("img");
     img.width = width;
     img.height = height;
   
     img.addEventListener("load", () => {
+      // Then we write the image pixels to a canvas.
       const canvas = document.createElement("canvas");
       canvas.width = width;
       canvas.height = height;

--- a/js/convertSVG.js
+++ b/js/convertSVG.js
@@ -1,0 +1,118 @@
+import { Species } from "../crate/pkg/sandtable";
+
+export function rgbaToSpecies(r, g, b, a) {
+  // Transparent to Empty
+  if (a < 250) {
+    return 0;
+  }
+
+  r /= 255;
+  g /= 255;
+  b /= 255;
+
+  // https://github.com/Qix-/color-convert/blob/master/conversions.js#L58
+  const min = Math.min(r, g, b);
+  const max = Math.max(r, g, b);
+  const delta = max - min;
+  let h;
+  let s;
+
+  if (max === min) {
+    h = 0;
+  } else if (r === max) {
+    h = (g - b) / delta;
+  } else if (g === max) {
+    h = 2 + (b - r) / delta;
+  } else if (b === max) {
+    h = 4 + (r - g) / delta;
+  }
+
+  h = Math.min(h * 60, 360);
+
+  if (h < 0) {
+    h += 360;
+  }
+
+  const l = (min + max) / 2;
+
+  if (max === min) {
+    s = 0;
+  } else if (l <= 0.5) {
+    s = delta / (max + min);
+  } else {
+    s = delta / (2 - max - min);
+  }
+
+  // Greyscale options
+  if (s < 0.05) {
+    // Black to Wall
+    if (l < 0.05) {
+      return Species.Wall;
+    }
+    // White to Empty
+    if (l > 0.95) {
+      return Species.Empty;
+    }
+    // Light grey to Sand
+    if (l > 0.5) {
+      return Species.Sand;
+    }
+  }
+
+  // Color options
+  let hueIndex = Math.floor((h+30) / 360 * 7);
+  let lightnessIndex = Math.floor(l * 4 - 0.25);
+
+  const colorsToSpecies = [
+    [ Species.Fire, Species.Lava, Species.Rocket], // Red
+    [ Species.Wood, null, Species.Gas], // Yellow
+    [ Species.Plant, Species.Dust, Species.Acid], // Green
+    [ Species.Plant, Species.Dust, Species.Acid ], // Green2: duplicate b/c they are perceptually close
+    [ Species.Water, Species.Ice, Species.Stone ], // Blue
+    [ Species.Oil, Species.Seed, Species.Fungus], // Purple
+    [ Species.Cloner, Species.Mite, null ], // Violet
+  ];
+
+  const species = colorsToSpecies[hueIndex][lightnessIndex];
+
+  return species ? species : Species.Empty;
+}
+
+export async function svgToImageData (svgString) {
+  const width = 300;
+  const height = 300;
+
+  return new Promise((resolve, reject) => {
+    // To fit any SVG, we would need to parse the SVG string and set the width
+    // and height attributes to 300. It seems safer to not parse the SVG, and
+    // just load it in an image element.
+    const blob = new Blob([svgString], {type: 'image/svg+xml'});
+    const img = document.createElement("img");
+    img.width = width;
+    img.height = height;
+  
+    img.addEventListener("load", () => {
+      const canvas = document.createElement("canvas");
+      canvas.width = width;
+      canvas.height = height;
+      const ctx = canvas.getContext("2d");
+      
+      // Transform context to match Sandspiel Universe
+      ctx.translate(canvas.width / 2, canvas.height / 2);
+      ctx.rotate((-90 * Math.PI) / 180);
+      ctx.scale(-1, 1.0);
+      ctx.translate(-canvas.width / 2, -canvas.height / 2);
+  
+      ctx.drawImage(img, 0, 0);
+  
+      const imgData = ctx.getImageData(0, 0, width, height);
+      resolve(imgData);
+    });
+
+    img.addEventListener('error', function (error) {
+      reject(error);
+    })
+
+    img.src = URL.createObjectURL(blob);
+  });
+}

--- a/js/index.js
+++ b/js/index.js
@@ -132,5 +132,13 @@ document.addEventListener("keydown", function (event) {
   }
 });
 
+document.addEventListener("paste", function(event) {
+  const text = event.clipboardData.getData('text/plain');
+  if (text.includes("<svg")) {
+    event.preventDefault();
+    window.UI.loadSVG(text);
+  }
+});
+
 (adsbygoogle = window.adsbygoogle || []).push({});
 export { canvas, width, height, universe, reset };


### PR DESCRIPTION
This 300x300 SVG ([Cuttle source design](https://cuttle.xyz/@forresto/Sand-palette-roVmJLuqtGys), with colors as named parameters.)

![Cuttle](https://user-images.githubusercontent.com/395307/192168439-2004ab35-09fb-4e3a-8513-b586cabdbc1a.svg) 

pasted into this branch loads to this composition with all Species represented

<img src="https://user-images.githubusercontent.com/395307/192168471-2836d0da-eae7-4a13-bbef-fee7265b1c77.png" width="400" />

Color matching is fuzzy, so a range of colors will match: 

![Figma gradients](https://user-images.githubusercontent.com/395307/192168558-ff858ad8-4b9d-4676-974f-08b3ee20aed3.svg)

<img src="https://user-images.githubusercontent.com/395307/192168569-28cf6d97-3d15-44c6-a028-6ffef6361a38.png" width="400" />

There are some holes in the simple HSL grid for future Species. I wouldn't worry about backwards-compatibility, if the colors are translated differently in the future. There could be a less-specific mapping, but after playing with it a bit I wanted to choose the color ranges. 